### PR TITLE
Allow unfolding all foldables by default

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -215,7 +215,7 @@ func run() {
 		WdPkgsListingManner:    wdPkgsListingManner,
 		FooterShowingManner:    footerShowingManner,
 		RenderDocLinks:         *renderDocLinksFlag,
-		UnfoldAllByDefault:     *unfoldAllByDefaultFlag,
+		UnfoldAllInitially:     *unfoldAllInitiallyFlag,
 		VerboseLogs:            verboseMode,
 	}
 
@@ -287,7 +287,7 @@ var allowNetworkConnection = flag.Bool("allow-network-connection", false, "speci
 var footerShowingMannerFlag = flag.String("footer", "verbose+qrcode", "verbose+qrcode | verbose | simple | none")
 
 var renderDocLinksFlag = flag.Bool("render-doclinks", false, "render links in doc comments")
-var unfoldAllByDefaultFlag = flag.Bool("unfold-all-by-default", false, "unfold all foldables by default")
+var unfoldAllInitiallyFlag = flag.Bool("unfold-all-initially", false, "unfold all foldables initially")
 
 // depreciated by "-wdpkgs-listing=promoted" since v0.1.8
 var emphasizeWdPackagesFlag = flag.Bool("emphasize-wdpkgs", false, "promote working directory packages")
@@ -387,8 +387,8 @@ Options:
 		  and a qr-code.
 	-render-doclinks
 		Whether or not to render the links in docs.
-	-unfold-all-by-default
-	  Unfold all foldables by default.
+	-unfold-all-initially
+		Unfold all foldables initially.
 
 Examples:
 	%[1]v std

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -215,6 +215,7 @@ func run() {
 		WdPkgsListingManner:    wdPkgsListingManner,
 		FooterShowingManner:    footerShowingManner,
 		RenderDocLinks:         *renderDocLinksFlag,
+		UnfoldAllByDefault:     *unfoldAllByDefaultFlag,
 		VerboseLogs:            verboseMode,
 	}
 
@@ -286,6 +287,7 @@ var allowNetworkConnection = flag.Bool("allow-network-connection", false, "speci
 var footerShowingMannerFlag = flag.String("footer", "verbose+qrcode", "verbose+qrcode | verbose | simple | none")
 
 var renderDocLinksFlag = flag.Bool("render-doclinks", false, "render links in doc comments")
+var unfoldAllByDefaultFlag = flag.Bool("unfold-all-by-default", false, "unfold all foldables by default")
 
 // depreciated by "-wdpkgs-listing=promoted" since v0.1.8
 var emphasizeWdPackagesFlag = flag.Bool("emphasize-wdpkgs", false, "promote working directory packages")
@@ -385,6 +387,8 @@ Options:
 		  and a qr-code.
 	-render-doclinks
 		Whether or not to render the links in docs.
+	-unfold-all-by-default
+	  Unfold all foldables by default.
 
 Examples:
 	%[1]v std

--- a/internal/server/page.go
+++ b/internal/server/page.go
@@ -24,6 +24,7 @@ type PageOutputOptions struct {
 	AllowNetworkConnection bool
 	VerboseLogs            bool
 	RenderDocLinks         bool
+	UnfoldAllByDefault     bool
 	SourceReadingStyle     string
 	WdPkgsListingManner    string
 	FooterShowingManner    string
@@ -51,7 +52,8 @@ var (
 	wdPkgsListingManner    = WdPkgsListingManner_general
 	footerShowingManner    = FooterShowingManner_none
 
-	renderDocLinks = false
+	renderDocLinks     = false
+	unfoldAllByDefault = false
 
 	verboseLogs = false
 
@@ -70,6 +72,7 @@ func setPageOutputOptions(options PageOutputOptions, forTesting bool) {
 	collectUnexporteds = !options.NotCollectUnexporteds || forTesting
 	allowNetworkConnection = options.AllowNetworkConnection && !forTesting
 	renderDocLinks = options.RenderDocLinks || forTesting
+	unfoldAllByDefault = options.UnfoldAllByDefault && !forTesting
 	wdPkgsListingManner = options.WdPkgsListingManner
 	footerShowingManner = options.FooterShowingManner
 	verboseLogs = options.VerboseLogs

--- a/internal/server/page.go
+++ b/internal/server/page.go
@@ -24,7 +24,7 @@ type PageOutputOptions struct {
 	AllowNetworkConnection bool
 	VerboseLogs            bool
 	RenderDocLinks         bool
-	UnfoldAllByDefault     bool
+	UnfoldAllInitially     bool
 	SourceReadingStyle     string
 	WdPkgsListingManner    string
 	FooterShowingManner    string
@@ -53,7 +53,7 @@ var (
 	footerShowingManner    = FooterShowingManner_none
 
 	renderDocLinks     = false
-	unfoldAllByDefault = false
+	unfoldAllInitially = false
 
 	verboseLogs = false
 
@@ -72,7 +72,7 @@ func setPageOutputOptions(options PageOutputOptions, forTesting bool) {
 	collectUnexporteds = !options.NotCollectUnexporteds || forTesting
 	allowNetworkConnection = options.AllowNetworkConnection && !forTesting
 	renderDocLinks = options.RenderDocLinks || forTesting
-	unfoldAllByDefault = options.UnfoldAllByDefault && !forTesting
+	unfoldAllInitially = options.UnfoldAllInitially && !forTesting
 	wdPkgsListingManner = options.WdPkgsListingManner
 	footerShowingManner = options.FooterShowingManner
 	verboseLogs = options.VerboseLogs

--- a/internal/server/page_package-details.go
+++ b/internal/server/page_package-details.go
@@ -2717,7 +2717,7 @@ func writeHiddenItemsHeader(page *htmlPage, resName, itemsCategory string, hideI
 
 func writeFoldingBlock(page *htmlPage, resName, statName, contentKind string, expandInitially bool, writeTitleContent, listStatContent func()) {
 	checked := ""
-	if expandInitially {
+	if expandInitially || unfoldAllByDefault {
 		checked = " checked"
 	}
 	labelClass := ""

--- a/internal/server/page_package-details.go
+++ b/internal/server/page_package-details.go
@@ -2717,7 +2717,7 @@ func writeHiddenItemsHeader(page *htmlPage, resName, itemsCategory string, hideI
 
 func writeFoldingBlock(page *htmlPage, resName, statName, contentKind string, expandInitially bool, writeTitleContent, listStatContent func()) {
 	checked := ""
-	if expandInitially || unfoldAllByDefault {
+	if expandInitially || unfoldAllInitially {
 		checked = " checked"
 	}
 	labelClass := ""


### PR DESCRIPTION
Hi @go101! 👋
I proposed a feature to allow unfolding all foldables by default with this PR.

I found out clicking the foldables over-and-over. By having all foldables being unfolded, I can see the whole documentation and fold whatever I need.

I'm sorry I didn't write the test for the changes as I can't run the test runner on my machine.

Thank you very much. Looking forward to hearing from you about this one.